### PR TITLE
Fix races

### DIFF
--- a/async-cortex-m/src/executor.rs
+++ b/async-cortex-m/src/executor.rs
@@ -32,7 +32,7 @@ static VTABLE: RawWakerVTable = {
         wake_by_ref(p)
     }
     unsafe fn wake_by_ref(p: *const ()) {
-        (*(p as *const AtomicBool)).store(true, Ordering::Relaxed)
+        (*(p as *const AtomicBool)).store(true, Ordering::Release)
     }
     unsafe fn drop(_: *const ()) {
         // no-op
@@ -67,8 +67,8 @@ impl Executor {
             unsafe { Waker::from_raw(RawWaker::new(&ready as *const _ as *const _, &VTABLE)) };
         let val = loop {
             // advance the main task
-            if ready.load(Ordering::Relaxed) {
-                ready.store(false, Ordering::Relaxed);
+            if ready.load(Ordering::Acquire) {
+                ready.store(false, Ordering::Release);
 
                 let mut cx = Context::from_waker(&waker);
                 if let Poll::Ready(val) = f.as_mut().poll(&mut cx) {
@@ -87,9 +87,10 @@ impl Executor {
                 // interrupt handlers (the only source of 'race conditions' (!= data races)) are
                 // "oneshot": they'll issue a `wake` and then disable themselves to not run again
                 // until the woken task has made more work
-                if task.ready.load(Ordering::Relaxed) {
+                if task.ready.load(Ordering::Acquire) {
+
                     // we are about to service the task so switch the `ready` flag to `false`
-                    task.ready.store(false, Ordering::Relaxed);
+                    task.ready.store(false, Ordering::Release);
 
                     // NOTE we never deallocate tasks so `&ready` is always pointing to
                     // allocated memory (`&'static AtomicBool`)


### PR DESCRIPTION
The problem happens when a task triggers an interrupt and interrupt processing takes place before `wfe`, waking the task. In this case the task is ready again, but not processed because MCU halts forever in `wfe`. This PR fixes the problem.