### PR TITLE
3-mutex-example: Update expected output

### DIFF
--- a/nrf52/examples/3-mutex.rs
+++ b/nrf52/examples/3-mutex.rs
@@ -13,9 +13,9 @@
 //! Expected output:
 //!
 //! ```
-//! B: before recv
-//! A: before send
-//! A: after send
+//! B: before lock
+//! A: before write
+//! A: after releasing the lock
 //! A: yield
 //! B: 42
 //! DONE


### PR DESCRIPTION
The current documented expected output for example `3-mutex` was copied from `4-channel` and not adjusted accordingly.